### PR TITLE
Fixed a relative path problem in makeing.py

### DIFF
--- a/port/makeimg.py
+++ b/port/makeimg.py
@@ -183,7 +183,7 @@ with open(file_out, "wb") as fout:
 
 # Generate .uf2 file if the SoC has native USB.
 if idf_target in ("ESP32S2", "ESP32S3"):
-    sys.path.append(os.path.join(os.path.dirname(__file__), "../../micropython/tools"))
+    sys.path.append(os.path.join(os.path.dirname(__file__), "../micropython/tools"))
     import uf2conv
 
     families = uf2conv.load_families()


### PR DESCRIPTION
### 编译环境

Ubuntu( Windows 11, WSL1 )

### 问题描述

我在本地按 port 目录下的 升级到 `micropython_v1.23.0.md` 所提供的步骤合并固件时，抛出了一个错误如下：

<img width="1896" height="672" alt="image" src="https://github.com/user-attachments/assets/d08fc80d-57aa-4602-a224-ff022acbd266" />

### 我所作出的更改

我认为这是一个具有普遍性的问题，故将 port/makeimg.py line 186 处代码更换为 `sys.path.append(os.path.join(os.path.dirname(__file__), "../micropython/tools"))` 并提交此 PR